### PR TITLE
refactor: replace chalk with small and fast ansis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 coverage
 dist

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ console.log(longHSVGradient(str));
 
 ## Dependencies
 
-- [chalk](https://github.com/chalk/chalk) - Output colored text to terminal
+- [ansis](https://github.com/webdiscus/ansis) - Output colored text to terminal
 - [tinygradient](https://github.com/mistic100/tinygradient) - Generate gradients
 
 ## Who uses gradient-string?

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
+        "ansis": "^3.5.2",
         "tinygradient": "^1.1.5"
       },
       "devDependencies": {
@@ -1100,6 +1100,15 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/ansis": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.5.2.tgz",
+      "integrity": "sha512-5uGcUZRbORJeEppVdWfZOSybTMz+Ou+84HepgK081Yk5+pPMMzWf/XGxiAT6bfBqCghRB4MwBtYn0CHqINRVag==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1164,6 +1173,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
       "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3475,6 +3485,11 @@
         "color-convert": "^2.0.1"
       }
     },
+    "ansis": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-3.5.2.tgz",
+      "integrity": "sha512-5uGcUZRbORJeEppVdWfZOSybTMz+Ou+84HepgK081Yk5+pPMMzWf/XGxiAT6bfBqCghRB4MwBtYn0CHqINRVag=="
+    },
     "assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3526,7 +3541,8 @@
     "chalk": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true
     },
     "check-error": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "chalk": "^5.3.0",
+    "ansis": "^3.5.2",
     "tinygradient": "^1.1.5"
   },
   "devDependencies": {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,12 +1,9 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import chalk from 'chalk';
+import { describe, it, expect } from 'vitest';
+// Force use 256 colors, must be imported before ansis
+import './level-256colors';
 import gradient, { rainbow, cristal, pastel, atlas } from '.';
 
 describe('Gradient Tests', () => {
-  beforeEach(() => {
-    chalk.level = 2;
-  });
-
   it('should throw an error if wrong gradient arguments are passed', () => {
     expect(() => gradient()('abc')).toThrowError('Missing gradient colors');
     expect(() => gradient('red')('abc')).toThrowError('Expected an array of colors, received "red"');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import chalk from 'chalk';
+import { hex } from 'ansis';
 import tinygradient, { StopInput, Instance as TinyGradient, ArcMode } from 'tinygradient';
 import { ColorInput, Instance as TinyColor } from 'tinycolor2';
 
@@ -113,7 +113,7 @@ function applyGradient(str: string, gradient: TinyGradient, opts?: GradientOptio
   let result = '';
 
   for (const s of str) {
-    result += s.match(/\s/g) ? s : chalk.hex(colors.shift()?.toHex() || '#000')(s);
+    result += s.match(/\s/g) ? s : hex(colors.shift()?.toHex() || '#000')(s);
   }
 
   return result;
@@ -131,7 +131,7 @@ export function multiline(str: string, gradient: TinyGradient, opts?: GradientOp
     let lineResult = '';
 
     for (const l of line) {
-      lineResult += chalk.hex(lineColors.shift()?.toHex() || '#000')(l);
+      lineResult += hex(lineColors.shift()?.toHex() || '#000')(l);
     }
 
     results.push(lineResult);

--- a/src/level-256colors.js
+++ b/src/level-256colors.js
@@ -1,0 +1,2 @@
+// define color level that will be used by tests
+process.env.COLORTERM = 'ansi256';


### PR DESCRIPTION
Hello @bokub 

thank you for the awesome module.

The unpacked size of the `gradient-string` is only  [`18 kB`](https://www.npmjs.com/package/gradient-string), but the `chalk` dependency is [`44 kB`](https://www.npmjs.com/package/chalk).
This PR replaces the large `chalk` with smaller (only [`7 kB`](https://www.npmjs.com/package/ansis)) and faster alternative [ansis](https://github.com/webdiscus/ansis).
The functionality of `ansis` is the same as `chalk`. 
Ansis supports Truecolor and ANSI 256 colors with [fallback](https://github.com/webdiscus/ansis#fallback): Truecolor → 256 colors → 16 colors → no colors.


All tests are passed.

P.S.: If you are not interested in reducing the size of dependencies, just close this PR.